### PR TITLE
Add filesystem browser dialog for selecting disk and recovery folders

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import logsRoutes from "./routes/logs.js";
 import schedulesRoutes from "./routes/schedules.js";
 import notificationsRoutes from "./routes/notifications.js";
 import authRoutes from "./routes/auth.js";
+import filesystemRoutes from "./routes/filesystem.js";
 import { initializeWebSocket } from "./websocket.js";
 import { initializeScheduler } from "./services/scheduler.js";
 import { createSessionMiddleware, authMiddleware } from "./middleware/auth.js";
@@ -55,6 +56,7 @@ app.use("/api", snapraidRoutes);
 app.use("/api/logs", logsRoutes);
 app.use("/api/schedules", schedulesRoutes);
 app.use("/api/notifications", notificationsRoutes);
+app.use("/api", filesystemRoutes);
 
 // Health check
 app.get("/api/health", (_req, res) => {

--- a/backend/src/routes/filesystem.ts
+++ b/backend/src/routes/filesystem.ts
@@ -1,0 +1,76 @@
+import { Router, type IRouter } from "express";
+import path from "path";
+import fs from "fs/promises";
+import type { FileSystemEntry, FileSystemResponse } from "@snapraid-webui/shared";
+
+const router: IRouter = Router();
+const basePath = path.resolve(import.meta.dir, "../..");
+
+router.get("/fs", async (req, res) => {
+  try {
+    const requestedPath = typeof req.query.path === "string" ? req.query.path : "";
+    const resolvedPath = requestedPath
+      ? path.resolve(basePath, requestedPath)
+      : basePath;
+
+    if (!resolvedPath.startsWith(basePath)) {
+      res.status(400).json({ error: "Path outside of base directory" });
+      return;
+    }
+
+    const stats = await fs.stat(resolvedPath).catch(() => null);
+    if (!stats || !stats.isDirectory()) {
+      res.status(404).json({ error: "Directory not found" });
+      return;
+    }
+
+    const dirents = await fs.readdir(resolvedPath, { withFileTypes: true });
+    const entries: FileSystemEntry[] = [];
+
+    for (const dirent of dirents) {
+      if (dirent.isSymbolicLink()) {
+        continue;
+      }
+
+      const fullPath = path.join(resolvedPath, dirent.name);
+      let size: number | undefined;
+
+      if (dirent.isFile()) {
+        const entryStats = await fs.stat(fullPath).catch(() => null);
+        size = entryStats?.size;
+      }
+
+      entries.push({
+        name: dirent.name,
+        path: fullPath,
+        isDirectory: dirent.isDirectory(),
+        size,
+      });
+    }
+
+    entries.sort((a, b) => {
+      if (a.isDirectory !== b.isDirectory) {
+        return a.isDirectory ? -1 : 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    const parentPath =
+      resolvedPath === basePath ? null : path.dirname(resolvedPath);
+
+    const response: FileSystemResponse = {
+      basePath,
+      path: resolvedPath,
+      parentPath:
+        parentPath && parentPath.startsWith(basePath) ? parentPath : null,
+      entries,
+    };
+
+    res.json(response);
+  } catch (error) {
+    console.error("Error reading filesystem:", error);
+    res.status(500).json({ error: "Failed to read directory" });
+  }
+});
+
+export default router;

--- a/frontend/src/components/FileSystemDialog.tsx
+++ b/frontend/src/components/FileSystemDialog.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useGetFileSystemEntriesQuery } from "@/store/api";
+import { cn } from "@/lib/utils";
+import { Folder, File, ArrowUp, RefreshCw } from "lucide-react";
+
+interface FileSystemDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (path: string) => void;
+  title?: string;
+  description?: string;
+  initialPath?: string;
+}
+
+export function FileSystemDialog({
+  open,
+  onOpenChange,
+  onSelect,
+  title = "Select folder",
+  description = "Browse the container filesystem to choose a folder.",
+  initialPath,
+}: FileSystemDialogProps) {
+  const [currentPath, setCurrentPath] = useState<string | undefined>(undefined);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  const { data, isFetching, refetch } = useGetFileSystemEntriesQuery(
+    { path: currentPath },
+    { skip: !open }
+  );
+
+  useEffect(() => {
+    if (open) {
+      setCurrentPath(initialPath);
+    } else {
+      setSelectedPath(null);
+    }
+  }, [open, initialPath]);
+
+  useEffect(() => {
+    if (data?.path) {
+      setSelectedPath(data.path);
+    }
+  }, [data?.path]);
+
+  const entries = useMemo(() => data?.entries ?? [], [data?.entries]);
+
+  const handleSelect = () => {
+    if (!selectedPath) return;
+    onSelect(selectedPath);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl" showCloseButton>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => data?.parentPath && setCurrentPath(data.parentPath)}
+              disabled={!data?.parentPath}
+            >
+              <ArrowUp className="h-4 w-4 mr-1" />
+              Up
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => refetch()}
+              disabled={isFetching}
+            >
+              <RefreshCw className={cn("h-4 w-4 mr-1", isFetching && "animate-spin")} />
+              Refresh
+            </Button>
+            <div className="text-sm text-muted-foreground truncate">
+              {data?.path ?? "Loading..."}
+            </div>
+          </div>
+
+          <div className="rounded-lg border">
+            <ScrollArea className="h-[320px]">
+              {entries.length === 0 && !isFetching ? (
+                <div className="p-6 text-center text-sm text-muted-foreground">
+                  This folder is empty.
+                </div>
+              ) : (
+                <div className="divide-y">
+                  {entries.map((entry) => (
+                    <button
+                      key={entry.path}
+                      type="button"
+                      className={cn(
+                        "flex w-full items-center justify-between gap-4 px-4 py-3 text-left text-sm transition",
+                        "hover:bg-muted/40",
+                        selectedPath === entry.path && "bg-muted/60"
+                      )}
+                      onClick={() => {
+                        if (entry.isDirectory) {
+                          setSelectedPath(entry.path);
+                        }
+                      }}
+                    >
+                      <div className="flex items-center gap-2">
+                        {entry.isDirectory ? (
+                          <Folder className="h-4 w-4 text-sky-500" />
+                        ) : (
+                          <File className="h-4 w-4 text-muted-foreground" />
+                        )}
+                        <span className="font-medium">{entry.name}</span>
+                      </div>
+                      {entry.isDirectory ? (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setCurrentPath(entry.path);
+                          }}
+                        >
+                          Open
+                        </Button>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">
+                          {entry.size !== undefined ? `${entry.size} B` : "File"}
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </ScrollArea>
+          </div>
+
+          <div className="text-xs text-muted-foreground">
+            Base: {data?.basePath ?? "-"}
+          </div>
+        </div>
+
+        <DialogFooter showCloseButton={false}>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSelect} disabled={!selectedPath}>
+            Select folder
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/components/disks/ContentFilesCard.tsx
+++ b/frontend/src/pages/components/disks/ContentFilesCard.tsx
@@ -7,7 +7,9 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { FileBraces, Plus, Trash2 } from "lucide-react";
+import { FileBraces, FolderOpen, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { FileSystemDialog } from "@/components/FileSystemDialog";
 
 interface ContentFilesCardProps {
   content: string[];
@@ -22,6 +24,8 @@ export function ContentFilesCard({
   onRemove,
   onUpdate,
 }: ContentFilesCardProps) {
+  const [isBrowserOpen, setIsBrowserOpen] = useState(false);
+  const [browserTarget, setBrowserTarget] = useState<number | null>(null);
   return (
     <Card>
       <CardHeader>
@@ -48,6 +52,16 @@ export function ContentFilesCard({
                 className="flex-1"
               />
               <Button
+                variant="outline"
+                size="icon"
+                onClick={() => {
+                  setBrowserTarget(index);
+                  setIsBrowserOpen(true);
+                }}
+              >
+                <FolderOpen className="h-4 w-4" />
+              </Button>
+              <Button
                 variant="ghost"
                 size="icon"
                 onClick={() => onRemove(index)}
@@ -67,6 +81,17 @@ export function ContentFilesCard({
           Add Content
         </Button>
       </CardContent>
+      <FileSystemDialog
+        open={isBrowserOpen}
+        onOpenChange={setIsBrowserOpen}
+        title="Select disk folder"
+        description="Choose the folder that contains the disk data."
+        onSelect={(path) => {
+          if (browserTarget) {
+            onUpdate(browserTarget, path);
+          }
+        }}
+      />
     </Card>
   );
 }

--- a/frontend/src/pages/components/disks/DataDisksCard.tsx
+++ b/frontend/src/pages/components/disks/DataDisksCard.tsx
@@ -7,7 +7,9 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { HardDrive, Plus, Trash2 } from "lucide-react";
+import { FolderOpen, HardDrive, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { FileSystemDialog } from "@/components/FileSystemDialog";
 
 interface DataDisksCardProps {
   data: Record<string, string>;
@@ -23,7 +25,8 @@ export function DataDisksCard({
   onUpdate,
 }: DataDisksCardProps) {
   const entries = Object.entries(data);
-
+  const [isBrowserOpen, setIsBrowserOpen] = useState(false);
+  const [browserTarget, setBrowserTarget] = useState<string | null>(null);
   return (
     <Card>
       <CardHeader>
@@ -55,7 +58,21 @@ export function DataDisksCard({
                 placeholder="/mnt/disk1/"
                 className="flex-1"
               />
-              <Button variant="ghost" size="icon" onClick={() => onRemove(name)}>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => {
+                  setBrowserTarget(name);
+                  setIsBrowserOpen(true);
+                }}
+              >
+                <FolderOpen className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => onRemove(name)}
+              >
                 <Trash2 className="h-4 w-4 text-destructive" />
               </Button>
             </div>
@@ -71,6 +88,17 @@ export function DataDisksCard({
           Add Disk
         </Button>
       </CardContent>
+      <FileSystemDialog
+        open={isBrowserOpen}
+        onOpenChange={setIsBrowserOpen}
+        title="Select disk folder"
+        description="Choose the folder that contains the disk data."
+        onSelect={(path) => {
+          if (browserTarget !== null) {
+            onUpdate(browserTarget, browserTarget, path);
+          }
+        }}
+      />
     </Card>
   );
 }

--- a/frontend/src/pages/components/disks/ParityDisksCard.tsx
+++ b/frontend/src/pages/components/disks/ParityDisksCard.tsx
@@ -7,7 +7,9 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Plus, Shield, Trash2 } from "lucide-react";
+import { FolderOpen, Plus, Shield, Trash2 } from "lucide-react";
+import { FileSystemDialog } from "@/components/FileSystemDialog";
+import { useState } from "react";
 
 interface ParityDisksCardProps {
   parity: string[];
@@ -22,6 +24,8 @@ export function ParityDisksCard({
   onRemove,
   onUpdate,
 }: ParityDisksCardProps) {
+  const [isBrowserOpen, setIsBrowserOpen] = useState(false);
+  const [browserTarget, setBrowserTarget] = useState<number | null>(null);
   return (
     <Card>
       <CardHeader>
@@ -54,6 +58,16 @@ export function ParityDisksCard({
                 className="flex-1"
               />
               <Button
+                variant="outline"
+                size="icon"
+                onClick={() => {
+                  setBrowserTarget(index);
+                  setIsBrowserOpen(true);
+                }}
+              >
+                <FolderOpen className="h-4 w-4" />
+              </Button>
+              <Button
                 variant="ghost"
                 size="icon"
                 onClick={() => onRemove(index)}
@@ -73,6 +87,17 @@ export function ParityDisksCard({
           Add Parity
         </Button>
       </CardContent>
+      <FileSystemDialog
+        open={isBrowserOpen}
+        onOpenChange={setIsBrowserOpen}
+        title="Select disk folder"
+        description="Choose the folder that contains the disk data."
+        onSelect={(path) => {
+          if (browserTarget !== null) {
+            onUpdate(browserTarget, path);
+          }
+        }}
+      />
     </Card>
   );
 }

--- a/frontend/src/pages/components/recovery/RecoveryOptionsCard.tsx
+++ b/frontend/src/pages/components/recovery/RecoveryOptionsCard.tsx
@@ -17,7 +17,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { FieldDescription } from "@/components/ui/field";
-import { Bug, Play, RotateCcw, Square, Trash } from "lucide-react";
+import { Bug, FolderOpen, Play, RotateCcw, Square, Trash } from "lucide-react";
+import { useState } from "react";
+import { FileSystemDialog } from "@/components/FileSystemDialog";
 
 interface RecoveryOptionsCardProps {
   filterPath: string;
@@ -56,6 +58,7 @@ export function RecoveryOptionsCard({
   onStartRecovery,
   onStopRecovery,
 }: RecoveryOptionsCardProps) {
+  const [isBrowserOpen, setIsBrowserOpen] = useState(false);
   return (
     <Card>
       <CardHeader>
@@ -107,17 +110,28 @@ export function RecoveryOptionsCard({
             <p className="text-xs text-muted-foreground">
               Limit recovery to specific paths. Supports wildcards:{" "}
               <code className="rounded bg-muted px-1">*</code> matches any
-              characters, <code className="rounded bg-muted px-1">?</code> matches
-              one character. Leave empty to recover all files matching other
-              filters.
+              characters, <code className="rounded bg-muted px-1">?</code>{" "}
+              matches one character. Leave empty to recover all files matching
+              other filters.
             </p>
           </FieldDescription>
-          <Input
-            id="filterPath"
-            value={filterPath}
-            onChange={(e) => onFilterPathChange(e.target.value)}
-            placeholder="e.g. /path/to/file or /directory/"
-          />
+          <div className="flex items-center gap-2">
+            <Input
+              id="filterPath"
+              value={filterPath}
+              onChange={(e) => onFilterPathChange(e.target.value)}
+              placeholder="e.g. /path/to/file or /directory/"
+            />
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => {
+                setIsBrowserOpen(true);
+              }}
+            >
+              <FolderOpen className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
 
         <div className="space-y-2">
@@ -127,7 +141,9 @@ export function RecoveryOptionsCard({
           </FieldDescription>
           <Select
             value={filterDisk || "all"}
-            onValueChange={(value) => onFilterDiskChange(value === "all" ? "" : value)}
+            onValueChange={(value) =>
+              onFilterDiskChange(value === "all" ? "" : value)
+            }
           >
             <SelectTrigger id="filterDisk">
               <SelectValue placeholder="All disks" />
@@ -195,6 +211,15 @@ export function RecoveryOptionsCard({
           )}
         </div>
       </CardContent>
+      <FileSystemDialog
+        open={isBrowserOpen}
+        onOpenChange={setIsBrowserOpen}
+        title="Select disk folder"
+        description="Choose the folder that contains the disk data."
+        onSelect={(path) => {
+          onFilterPathChange(path);
+        }}
+      />
     </Card>
   );
 }

--- a/frontend/src/store/api.ts
+++ b/frontend/src/store/api.ts
@@ -9,6 +9,7 @@ import type {
   NotificationSettings,
   AppConfig,
   ApiResponse,
+  FileSystemResponse,
 } from "@shared/types";
 
 export const api = createApi({
@@ -168,6 +169,14 @@ export const api = createApi({
     getAppConfig: builder.query<AppConfig, void>({
       query: () => "/app-config",
     }),
+
+    // File system
+    getFileSystemEntries: builder.query<FileSystemResponse, { path?: string }>({
+      query: ({ path }) => ({
+        url: "/fs",
+        params: path ? { path } : undefined,
+      }),
+    }),
   }),
 });
 
@@ -193,4 +202,5 @@ export const {
   useUpdateNotificationSettingsMutation,
   useTestNotificationMutation,
   useGetAppConfigQuery,
+  useGetFileSystemEntriesQuery,
 } = api;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -367,6 +367,13 @@ export interface FileSystemEntry {
   size?: number;
 }
 
+export interface FileSystemResponse {
+  basePath: string;
+  path: string;
+  parentPath: string | null;
+  entries: FileSystemEntry[];
+}
+
 export interface SnapRaidFileInfo {
   size: number;
   date: string;


### PR DESCRIPTION
### Motivation
- Provide an in-UI file and directory browser so users can navigate the container filesystem and pick folders when configuring disks or recovery filters.
- Keep filesystem access scoped and safe by rooting browsing to the application directory and skipping symlinks.

### Description
- Added a backend endpoint `GET /api/fs` that lists a directory rooted at the application base (`backend/src/routes/filesystem.ts`) and returns a typed `FileSystemResponse`; the route is mounted in the server router (`backend/src/index.ts`).
- Introduced `FileSystemResponse` into shared types (`shared/types.ts`) and added an RTK Query endpoint `getFileSystemEntries` with hook `useGetFileSystemEntriesQuery` (`frontend/src/store/api.ts`).
- Implemented a dialog-based file/directory picker component `FileSystemDialog` using the existing `Dialog` component which supports navigation (Up, Open), refresh, directory/file listing, selection, and shows the base path (`frontend/src/components/FileSystemDialog.tsx`).
- Integrated the picker into the Disks and Recovery pages, adding buttons to open the browser and wiring the selected folder into disk entries and the recovery filter input (`frontend/src/pages/Disks.tsx`, `frontend/src/pages/Recovery.tsx`).
- Backend safeguards: browsing is resolved against a `basePath` (app root), paths outside the base are rejected, symlinks are skipped, and results are sorted with directories first.

### Testing
- Attempted to install dependencies with `bun install`, but the install failed due to the npm registry returning 403 errors, preventing dependency resolution and running the dev servers (failed).
- Attempted to run the frontend/backend dev scripts (`bun run dev`, `bun run dev:backend`) but they could not start because dependencies were not installed (failed).
- No automated or unit tests were executed because the environment could not install packages or start the app; code changes are limited to additions and integrations described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d1a9d7bc483269b4f855e54e0b3b4)