### PR TITLE
Improve API error messaging in UI

### DIFF
--- a/frontend/src/lib/api-error.ts
+++ b/frontend/src/lib/api-error.ts
@@ -1,0 +1,63 @@
+type ErrorPayload = {
+  error?: unknown;
+  message?: unknown;
+  details?: unknown;
+};
+
+type ErrorWithData = {
+  data?: unknown;
+  error?: unknown;
+  message?: unknown;
+};
+
+const appendMessage = (messages: string[], value: unknown) => {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      messages.push(trimmed);
+    }
+  }
+};
+
+const appendDetails = (messages: string[], details: unknown) => {
+  if (Array.isArray(details)) {
+    details.forEach((detail) => appendMessage(messages, detail));
+    return;
+  }
+  appendMessage(messages, details);
+};
+
+export const getApiErrorMessage = (error: unknown): string => {
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (error && typeof error === "object") {
+    const messages: string[] = [];
+    const errorWithData = error as ErrorWithData;
+
+    if (typeof errorWithData.data === "string") {
+      appendMessage(messages, errorWithData.data);
+    } else if (errorWithData.data && typeof errorWithData.data === "object") {
+      const data = errorWithData.data as ErrorPayload;
+      appendMessage(messages, data.error);
+      appendMessage(messages, data.message);
+      appendDetails(messages, data.details);
+    }
+
+    appendMessage(messages, errorWithData.error);
+    appendMessage(messages, errorWithData.message);
+
+    if (messages.length > 0) {
+      return Array.from(new Set(messages)).join("\n");
+    }
+
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+
+  return String(error);
+};

--- a/frontend/src/pages/Disks.tsx
+++ b/frontend/src/pages/Disks.tsx
@@ -16,6 +16,7 @@ import { ParityDisksCard } from "@/pages/components/disks/ParityDisksCard";
 import { DataDisksCard } from "@/pages/components/disks/DataDisksCard";
 import { ContentFilesCard } from "@/pages/components/disks/ContentFilesCard";
 import { RawConfigEditor } from "@/pages/components/disks/RawConfigEditor";
+import { getApiErrorMessage } from "@/lib/api-error";
 
 export function Disks() {
   const { data: config, isLoading } = useGetConfigQuery();
@@ -125,7 +126,7 @@ export function Disks() {
       setEditedConfig(null);
     } catch (error) {
       toast.error("Failed to save configuration", {
-        description: String(error),
+        description: getApiErrorMessage(error),
       });
     }
   };
@@ -137,7 +138,7 @@ export function Disks() {
       setEditedRaw("");
     } catch (error) {
       toast.error("Failed to save configuration", {
-        description: String(error),
+        description: getApiErrorMessage(error),
       });
     }
   };

--- a/frontend/src/pages/Operations.tsx
+++ b/frontend/src/pages/Operations.tsx
@@ -18,6 +18,7 @@ import { PageHeader } from "@/pages/components/PageHeader";
 import { CommandSelectionCard } from "@/pages/components/operations/CommandSelectionCard";
 import { CommandOptionsCard } from "@/pages/components/operations/CommandOptionsCard";
 import { CommandOutputCard } from "@/pages/components/operations/CommandOutputCard";
+import { getApiErrorMessage } from "@/lib/api-error";
 
 export function Operations() {
   const dispatch = useDispatch();
@@ -74,14 +75,9 @@ export function Operations() {
           description: `${cmd.name} executed successfully`,
         });
       } catch (error) {
-        const message =
-          error &&
-          typeof error === "object" &&
-          "error" in error &&
-          typeof (error as { error: unknown }).error === "string"
-            ? (error as { error: string }).error
-            : String(error);
-        toast.error("Command failed", { description: message });
+        toast.error("Command failed", {
+          description: getApiErrorMessage(error),
+        });
       }
     }
   };

--- a/frontend/src/pages/Schedules.tsx
+++ b/frontend/src/pages/Schedules.tsx
@@ -22,6 +22,7 @@ import {
   type ScheduleFormData,
 } from "@/pages/components/schedules/ScheduleFormDialog";
 import { ScheduleList } from "@/pages/components/schedules/ScheduleList";
+import { getApiErrorMessage } from "@/lib/api-error";
 
 const CRON_PRESETS = [
   { label: "Every day at 2 AM", value: "0 2 * * *" },
@@ -113,7 +114,7 @@ export function Schedules() {
       }
       resetForm();
     } catch (error) {
-      toast.error("Error", { description: String(error) });
+      toast.error("Error", { description: getApiErrorMessage(error) });
     }
   };
 
@@ -124,7 +125,7 @@ export function Schedules() {
       await deleteSchedule(id).unwrap();
       toast.success("Schedule deleted");
     } catch (error) {
-      toast.error("Error", { description: String(error) });
+      toast.error("Error", { description: getApiErrorMessage(error) });
     }
   };
 
@@ -135,7 +136,7 @@ export function Schedules() {
         updates: { enabled: !schedule.enabled },
       }).unwrap();
     } catch (error) {
-      toast.error("Error", { description: String(error) });
+      toast.error("Error", { description: getApiErrorMessage(error) });
     }
   };
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -38,6 +38,7 @@ import { getEmptyChannelConfig } from "@/lib/notification-channel-utils";
 import { PageHeader } from "@/pages/components/PageHeader";
 import { PageLoading } from "@/pages/components/PageLoading";
 import { NotificationProviderCard } from "@/pages/components/settings/NotificationProviderCard";
+import { getApiErrorMessage } from "@/lib/api-error";
 
 export function Settings() {
   const { data: notificationSettings, isLoading } =
@@ -64,7 +65,9 @@ export function Settings() {
       setSettings(updated);
       toast.success("Notification settings saved");
     } catch (error) {
-      toast.error("Failed to save settings", { description: String(error) });
+      toast.error("Failed to save settings", {
+        description: getApiErrorMessage(error),
+      });
       throw error;
     }
   };
@@ -91,7 +94,7 @@ export function Settings() {
       toast.success(`${channel} configuration removed`);
     } catch (error) {
       toast.error("Failed to remove configuration", {
-        description: String(error),
+        description: getApiErrorMessage(error),
       });
     }
   };

--- a/frontend/src/pages/components/settings/NotificationProviderCard.tsx
+++ b/frontend/src/pages/components/settings/NotificationProviderCard.tsx
@@ -16,6 +16,7 @@ import {
   getChannelConfigSummary,
 } from "@/lib/notification-channel-utils";
 import { useUpdateNotificationSettingsMutation } from "@/store/api";
+import { getApiErrorMessage } from "@/lib/api-error";
 
 interface NotificationProviderCardProps {
   channel: NotificationChannel;
@@ -56,7 +57,9 @@ export function NotificationProviderCard({
       );
     } catch (error) {
       setSettings(settings);
-      toast.error("Failed to update", { description: String(error) });
+      toast.error("Failed to update", {
+        description: getApiErrorMessage(error),
+      });
     }
   };
 


### PR DESCRIPTION
### Motivation
- API errors returned from the backend were rendered as generic objects (e.g. "[Object Object]") and users could not see useful error text or details such as the `details` array. 
- Surface backend-provided `error`, `message`, and `details` fields in toast notifications so users can act on meaningful messages.

### Description
- Added `frontend/src/lib/api-error.ts` which exports `getApiErrorMessage(error: unknown): string` that extracts and formats `data.error`, `data.message`, `data.details`, top-level `error`/`message`, and falls back to JSON/stringification. 
- Replaced `String(error)` usage in several error handlers to use `getApiErrorMessage` in `Disks`, `Schedules`, `Operations`, and `Settings` pages. 
- Updated `NotificationProviderCard` to use the same formatter when toggling notification settings. 
- Simplified the operation error branch to use the shared formatter instead of ad-hoc object checks.

### Testing
- Ran typechecks with `bun run --filter @snapraid-webui/backend typecheck` and `bun run --filter @snapraid-webui/frontend typecheck`, both succeeded. 
- Ran frontend linter with `bun run --filter @snapraid-webui/frontend lint`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d24a799dc8326ad96cce16a724ee0)