### PR TITLE
Install curl and use curl for Docker HEALTHCHECK

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=frontend-builder /app/frontend/dist /temp/prod/frontend/dist
 # Final image: copy production node_modules and source (no bun install in final stage)
 FROM base AS release
 USER root
-RUN apt-get update && apt-get install -y smartmontools snapraid && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl smartmontools snapraid && rm -rf /var/lib/apt/lists/*
 
 COPY --from=install-prod /temp/prod /app
 COPY --from=frontend-builder /app/frontend/dist /app/frontend/dist
@@ -51,7 +51,7 @@ ENV SNAPRAID_BIN=/usr/bin/snapraid
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+  CMD curl --fail --silent --show-error http://localhost:3000/api/health || exit 1
 
 WORKDIR /app/backend
 CMD ["bun", "run", "src/index.ts"]


### PR DESCRIPTION
### Motivation
- The container was reported "unhealthy" because the `HEALTHCHECK` used `wget` which is not present in the final image, so the image needs a suitable HTTP client or an alternative health check (e.g. a TCP port check).

### Description
- Add `curl` to the `apt-get install` line in `docker/Dockerfile` and replace the `HEALTHCHECK` command from `wget` to `curl --fail --silent --show-error http://localhost:3000/api/health`.

### Testing
- Ran `bun run --filter @snapraid-webui/backend typecheck`, `bun run --filter @snapraid-webui/frontend typecheck`, and `bun run --filter @snapraid-webui/frontend lint`, and all commands exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d4627b2c4832688ebababefa8988b)