### PR TITLE
Remove 'Base:' label and serve filesystem from container root

### DIFF
--- a/backend/src/routes/filesystem.ts
+++ b/backend/src/routes/filesystem.ts
@@ -4,7 +4,7 @@ import fs from "fs/promises";
 import type { FileSystemEntry, FileSystemResponse } from "@snapraid-webui/shared";
 
 const router: IRouter = Router();
-const basePath = path.resolve(import.meta.dir, "../..");
+const basePath = path.parse(process.cwd()).root;
 
 router.get("/fs", async (req, res) => {
   try {

--- a/frontend/src/components/FileSystemDialog.tsx
+++ b/frontend/src/components/FileSystemDialog.tsx
@@ -150,9 +150,6 @@ export function FileSystemDialog({
             </ScrollArea>
           </div>
 
-          <div className="text-xs text-muted-foreground">
-            Base: {data?.basePath ?? "-"}
-          </div>
         </div>
 
         <DialogFooter showCloseButton={false}>


### PR DESCRIPTION
### Motivation
- The file browser needed to serve the container root so mounted disks are accessible, and the UI helper text showing the base path was unnecessary and cluttered the dialog.

### Description
- Change the backend `basePath` to the container root by setting `basePath = path.parse(process.cwd()).root` so the `/fs` API serves from the container root.
- Remove the `Base: ...` helper text from `frontend/src/components/FileSystemDialog.tsx` to simplify the dialog UI.
- Retain current safeguards that prevent resolving paths outside the `basePath` boundary.

### Testing
- Ran `bun run --filter @snapraid-webui/backend typecheck` and it succeeded (exit code 0). 
- Ran `bun run --filter @snapraid-webui/frontend typecheck` and it succeeded (exit code 0). 
- Ran `bun run --filter @snapraid-webui/frontend lint` and it succeeded (exit code 0). 
- Started the frontend dev server and captured a UI screenshot via Playwright to validate the dialog rendering, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d458be5b083268a6e5543db0bba40)