### PR TITLE
Fix auth middleware route matching, enforce session username, include cookies in API, and add tests

### DIFF
--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import type { NextFunction, Request, Response } from "express";
+import { authMiddleware } from "./auth";
+
+const envBackup = { ...process.env };
+
+const resetEnv = () => {
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, envBackup);
+};
+
+const createMockRes = () => {
+  let statusCode = 200;
+  let payload: unknown = undefined;
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(body: unknown) {
+      payload = body;
+      return res;
+    },
+  } as Response & { statusCode?: number; payload?: unknown };
+  Object.defineProperty(res, "statusCode", { get: () => statusCode });
+  Object.defineProperty(res, "payload", { get: () => payload });
+  return res;
+};
+
+const runMiddleware = async (req: Partial<Request>, res: Response) => {
+  let nextCalled = false;
+  const next: NextFunction = () => {
+    nextCalled = true;
+  };
+  await authMiddleware()(req as Request, res, next);
+  return nextCalled;
+};
+
+beforeEach(() => {
+  resetEnv();
+});
+
+afterEach(() => {
+  resetEnv();
+});
+
+describe("authMiddleware", () => {
+  test("allows auth status endpoint even when authentication is enabled", async () => {
+    process.env.AUTH_ENABLED = "true";
+    process.env.AUTH_USERNAME = "admin";
+    process.env.AUTH_PASSWORD_HASH = "hash";
+
+    const req = { path: "/auth/status" } as Partial<Request>;
+    const res = createMockRes();
+
+    const nextCalled = await runMiddleware(req, res);
+
+    expect(nextCalled).toBe(true);
+    expect((res as any).statusCode).toBe(200);
+  });
+
+  test("allows requests when authentication is disabled", async () => {
+    delete process.env.AUTH_ENABLED;
+    delete process.env.AUTH_PASSWORD_HASH;
+
+    const req = { path: "/api/config" } as Partial<Request>;
+    const res = createMockRes();
+
+    const nextCalled = await runMiddleware(req, res);
+
+    expect(nextCalled).toBe(true);
+    expect((res as any).statusCode).toBe(200);
+  });
+
+  test("allows requests when session is authenticated and username matches", async () => {
+    process.env.AUTH_ENABLED = "true";
+    process.env.AUTH_USERNAME = "admin";
+    process.env.AUTH_PASSWORD_HASH = "hash";
+
+    const req = {
+      path: "/api/config",
+      session: { authenticated: true, username: "admin" },
+    } as Partial<Request>;
+    const res = createMockRes();
+
+    const nextCalled = await runMiddleware(req, res);
+
+    expect(nextCalled).toBe(true);
+    expect((res as any).statusCode).toBe(200);
+  });
+
+  test("rejects requests when session is missing or username mismatched", async () => {
+    process.env.AUTH_ENABLED = "true";
+    process.env.AUTH_USERNAME = "admin";
+    process.env.AUTH_PASSWORD_HASH = "hash";
+
+    const session = { authenticated: true, username: "other" };
+    const req = {
+      path: "/api/config",
+      session,
+    } as Partial<Request>;
+    const res = createMockRes();
+
+    const nextCalled = await runMiddleware(req, res);
+
+    expect(nextCalled).toBe(false);
+    expect((res as any).statusCode).toBe(401);
+    expect((res as any).payload).toEqual({ error: "Authentication required" });
+    expect(session).toEqual({ authenticated: false, username: "" });
+  });
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -130,24 +130,28 @@ export async function createSessionMiddleware(): Promise<RequestHandler> {
  */
 export function authMiddleware() {
   return async (req: Request, res: Response, next: NextFunction) => {
-    // Skip auth for login/logout endpoints
-    if (
-      req.path === "/api/auth/login" ||
-      req.path === "/api/auth/logout" ||
-      req.path === "/api/auth/status"
-    ) {
+    // Skip auth for login/logout/status endpoints
+    if (req.path.startsWith("/auth/") || req.path === "/auth") {
       return next();
     }
 
-    // Check if auth is enabled
-    const enabled = await isAuthEnabled();
+    const settings = await loadAuthSettings();
+    const enabled = settings.enabled && settings.passwordHash !== "";
     if (!enabled) {
       return next();
     }
 
-    // Check if authenticated
-    if (req.session?.authenticated) {
+    if (
+      req.session?.authenticated &&
+      req.session.username &&
+      req.session.username === settings.username
+    ) {
       return next();
+    }
+
+    if (req.session) {
+      req.session.authenticated = false;
+      req.session.username = "";
     }
 
     res.status(401).json({ error: "Authentication required" });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,12 +8,20 @@ import { Recovery } from "./pages/Recovery";
 import { Logs } from "./pages/Logs";
 import { Settings } from "./pages/Settings";
 import { Toaster } from "./components/ui/sonner";
+import { AuthGate } from "./components/AuthGate";
 
 function App() {
   return (
     <>
       <Routes>
-        <Route path="/" element={<Layout />}>
+        <Route
+          path="/"
+          element={
+            <AuthGate>
+              <Layout />
+            </AuthGate>
+          }
+        >
           <Route index element={<Dashboard />} />
           <Route path="disks" element={<Disks />} />
           <Route path="operations" element={<Operations />} />

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { useGetAuthStatusQuery, useLoginMutation } from "@/store/api";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { PageLoading } from "@/pages/components/PageLoading";
+import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/api-error";
+
+type AuthGateProps = {
+  children: ReactNode;
+};
+
+export function AuthGate({ children }: AuthGateProps) {
+  const { data: status, isLoading } = useGetAuthStatusQuery();
+  const [login, { isLoading: isLoggingIn }] = useLoginMutation();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  useEffect(() => {
+    if (status?.username) {
+      setUsername(status.username);
+    }
+  }, [status?.username]);
+
+  if (isLoading || !status) {
+    return <PageLoading message="Checking authentication..." />;
+  }
+
+  if (!status.enabled || status.authenticated) {
+    return <>{children}</>;
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!username || !password) {
+      toast.error("Username and password are required");
+      return;
+    }
+    try {
+      await login({ username, password }).unwrap();
+      setPassword("");
+    } catch (error) {
+      toast.error("Login failed", {
+        description: getApiErrorMessage(error),
+      });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-6">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Sign in</CardTitle>
+          <CardDescription>
+            Enter your credentials to access the SnapRAID Web UI.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <Label htmlFor="auth-login-username">Username</Label>
+              <Input
+                id="auth-login-username"
+                autoComplete="username"
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="auth-login-password">Password</Label>
+              <Input
+                id="auth-login-password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={isLoggingIn}>
+              {isLoggingIn ? "Signing in..." : "Sign in"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -25,6 +25,10 @@ import {
   useGetNotificationSettingsQuery,
   useUpdateNotificationSettingsMutation,
   useTestNotificationMutation,
+  useGetAuthSettingsQuery,
+  useUpdateAuthSettingsMutation,
+  useGetAuthStatusQuery,
+  useLogoutMutation,
 } from "@/store/api";
 import { toast } from "sonner";
 import {
@@ -43,8 +47,14 @@ import { getApiErrorMessage } from "@/lib/api-error";
 export function Settings() {
   const { data: notificationSettings, isLoading } =
     useGetNotificationSettingsQuery();
+  const { data: authSettings, isLoading: isAuthLoading } =
+    useGetAuthSettingsQuery();
+  const { data: authStatus } = useGetAuthStatusQuery();
   const [updateNotificationSettings] = useUpdateNotificationSettingsMutation();
   const [testNotification] = useTestNotificationMutation();
+  const [updateAuthSettings, { isLoading: isSavingAuth }] =
+    useUpdateAuthSettingsMutation();
+  const [logout, { isLoading: isLoggingOut }] = useLogoutMutation();
 
   const [settings, setSettings] = useState<NotificationSettings | null>(null);
   const [editChannel, setEditChannel] = useState<NotificationChannel | null>(
@@ -52,12 +62,23 @@ export function Settings() {
   );
   const [removeChannel, setRemoveChannel] =
     useState<NotificationChannel | null>(null);
+  const [authEnabled, setAuthEnabled] = useState(false);
+  const [authUsername, setAuthUsername] = useState("admin");
+  const [authPassword, setAuthPassword] = useState("");
+  const [authConfirm, setAuthConfirm] = useState("");
 
   useEffect(() => {
     if (notificationSettings) {
       setSettings(notificationSettings);
     }
   }, [notificationSettings]);
+
+  useEffect(() => {
+    if (authSettings) {
+      setAuthEnabled(authSettings.enabled);
+      setAuthUsername(authSettings.username);
+    }
+  }, [authSettings]);
 
   const handleSaveFromDialog = async (updated: NotificationSettings) => {
     try {
@@ -99,7 +120,44 @@ export function Settings() {
     }
   };
 
-  if (isLoading || !settings) {
+  const handleSaveAuthSettings = async () => {
+    if (!authUsername.trim()) {
+      toast.error("Username is required");
+      return;
+    }
+    if (authPassword && authPassword !== authConfirm) {
+      toast.error("Passwords do not match");
+      return;
+    }
+
+    try {
+      await updateAuthSettings({
+        enabled: authEnabled,
+        username: authUsername.trim(),
+        password: authPassword ? authPassword : undefined,
+      }).unwrap();
+      setAuthPassword("");
+      setAuthConfirm("");
+      toast.success("Authentication settings saved");
+    } catch (error) {
+      toast.error("Failed to save authentication settings", {
+        description: getApiErrorMessage(error),
+      });
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      await logout().unwrap();
+      toast.success("Logged out");
+    } catch (error) {
+      toast.error("Failed to log out", {
+        description: getApiErrorMessage(error),
+      });
+    }
+  };
+
+  if (isLoading || !settings || isAuthLoading || !authSettings) {
     return <PageLoading message="Loading settings..." />;
   }
 
@@ -242,12 +300,19 @@ export function Settings() {
                     Require login to access the web UI
                   </p>
                 </div>
-                <Switch />
+                <Switch
+                  checked={authEnabled}
+                  onCheckedChange={setAuthEnabled}
+                />
               </div>
 
               <div className="space-y-2">
                 <Label htmlFor="auth-username">Username</Label>
-                <Input id="auth-username" defaultValue="admin" />
+                <Input
+                  id="auth-username"
+                  value={authUsername}
+                  onChange={(event) => setAuthUsername(event.target.value)}
+                />
               </div>
 
               <div className="space-y-2">
@@ -256,15 +321,35 @@ export function Settings() {
                   id="auth-password"
                   type="password"
                   placeholder="Leave empty to keep current"
+                  value={authPassword}
+                  onChange={(event) => setAuthPassword(event.target.value)}
                 />
               </div>
 
               <div className="space-y-2">
                 <Label htmlFor="auth-confirm">Confirm Password</Label>
-                <Input id="auth-confirm" type="password" />
+                <Input
+                  id="auth-confirm"
+                  type="password"
+                  value={authConfirm}
+                  onChange={(event) => setAuthConfirm(event.target.value)}
+                />
               </div>
 
-              <Button>Save Authentication Settings</Button>
+              <div className="flex flex-wrap gap-3">
+                <Button onClick={handleSaveAuthSettings} disabled={isSavingAuth}>
+                  {isSavingAuth ? "Saving..." : "Save Authentication Settings"}
+                </Button>
+                {authStatus?.authenticated && authEnabled && (
+                  <Button
+                    variant="outline"
+                    onClick={handleLogout}
+                    disabled={isLoggingOut}
+                  >
+                    {isLoggingOut ? "Logging out..." : "Log out"}
+                  </Button>
+                )}
+              </div>
             </CardContent>
           </Card>
         </TabsContent>

--- a/frontend/src/store/api.ts
+++ b/frontend/src/store/api.ts
@@ -10,13 +10,57 @@ import type {
   AppConfig,
   ApiResponse,
   FileSystemResponse,
+  AuthStatus,
+  AuthSettingsResponse,
+  AuthSettingsUpdate,
 } from "@shared/types";
 
 export const api = createApi({
   reducerPath: "api",
-  baseQuery: fetchBaseQuery({ baseUrl: "/api" }),
-  tagTypes: ["Status", "Config", "Schedules", "Logs", "Smart", "Notifications"],
+  baseQuery: fetchBaseQuery({ baseUrl: "/api", credentials: "include" }),
+  tagTypes: [
+    "Status",
+    "Config",
+    "Schedules",
+    "Logs",
+    "Smart",
+    "Notifications",
+    "Auth",
+  ],
   endpoints: (builder) => ({
+    // Auth
+    getAuthStatus: builder.query<AuthStatus, void>({
+      query: () => "/auth/status",
+      providesTags: ["Auth"],
+    }),
+    login: builder.mutation<{ success: boolean }, { username: string; password: string }>({
+      query: ({ username, password }) => ({
+        url: "/auth/login",
+        method: "POST",
+        body: { username, password },
+      }),
+      invalidatesTags: ["Auth"],
+    }),
+    logout: builder.mutation<{ success: boolean }, void>({
+      query: () => ({
+        url: "/auth/logout",
+        method: "POST",
+      }),
+      invalidatesTags: ["Auth"],
+    }),
+    getAuthSettings: builder.query<AuthSettingsResponse, void>({
+      query: () => "/auth/settings",
+      providesTags: ["Auth"],
+    }),
+    updateAuthSettings: builder.mutation<ApiResponse, AuthSettingsUpdate>({
+      query: (updates) => ({
+        url: "/auth/settings",
+        method: "PUT",
+        body: updates,
+      }),
+      invalidatesTags: ["Auth"],
+    }),
+
     // Status
     getStatus: builder.query<SnapRaidStatus, void>({
       query: () => "/status",
@@ -182,6 +226,11 @@ export const api = createApi({
 
 export const {
   useGetStatusQuery,
+  useGetAuthStatusQuery,
+  useLoginMutation,
+  useLogoutMutation,
+  useGetAuthSettingsQuery,
+  useUpdateAuthSettingsMutation,
   useGetConfigQuery,
   useGetRawConfigQuery,
   useUpdateConfigMutation,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -342,6 +342,23 @@ export interface AuthSettings {
   sessionSecret: string;
 }
 
+export interface AuthStatus {
+  enabled: boolean;
+  authenticated: boolean;
+  username: string | null;
+}
+
+export interface AuthSettingsResponse {
+  enabled: boolean;
+  username: string;
+}
+
+export interface AuthSettingsUpdate {
+  enabled?: boolean;
+  username?: string;
+  password?: string;
+}
+
 // ============================================================================
 // Log Types
 // ============================================================================


### PR DESCRIPTION
### Motivation
- Ensure authentication endpoints remain reachable when the backend is mounted under `/api` and that session enforcement actually checks the configured username. 
- Preserve session cookies on frontend requests so login/logout and status checks work from the browser. 
- Add targeted test coverage to guard the middleware behavior and prevent regressions.

### Description
- Change auth middleware to bypass any `/auth/*` or `/auth` paths by using `req.path.startsWith("/auth/") || req.path === "/auth"` so endpoints remain accessible when mounted under `/api`.
- Replace `isAuthEnabled()` usage with `loadAuthSettings()` and require that `req.session.username === settings.username` in addition to `req.session.authenticated`, and clear session fields on mismatch.
- Update frontend API base query to `fetchBaseQuery({ baseUrl: "/api", credentials: "include" })` so cookies are sent with requests and sessions persist.
- Add `backend/src/middleware/auth.test.ts` tests covering the `/auth/status` bypass, disabled auth, valid authenticated session, and rejection/clearing session on username mismatch, and wire up new auth-related frontend endpoints/types in `frontend/src/store/api.ts` and `shared/types.ts`.

### Testing
- Ran `bun test src/middleware/auth.test.ts` and observed `4 pass`, `0 fail` (all new middleware tests passed).
- Ran backend and frontend typechecks with `bun run --filter @snapraid-webui/backend typecheck` and `bun run --filter @snapraid-webui/frontend typecheck`, both succeeded.
- Ran frontend lint `bun run --filter @snapraid-webui/frontend lint`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d44302a3c832688181be12d772993)