### PR TITLE
Add per-channel notification event preferences

### DIFF
--- a/backend/src/services/notifications/index.ts
+++ b/backend/src/services/notifications/index.ts
@@ -6,6 +6,7 @@ import type {
   NotificationChannel,
   SnapRaidCommand,
 } from "@snapraid-webui/shared";
+import { NOTIFICATION_EVENTS } from "@snapraid-webui/shared";
 import { APP_CONFIG_FILE } from "../../config.js";
 import { sendDiscordNotification } from "./discord.js";
 import { sendTelegramNotification } from "./telegram.js";
@@ -15,8 +16,17 @@ import { sendSlackNotification } from "./slack.js";
 // Default notification settings
 const defaultSettings: NotificationSettings = {
   channels: {
-    discord: { enabled: false, webhookUrl: "" },
-    telegram: { enabled: false, botToken: "", chatId: "" },
+    discord: {
+      enabled: false,
+      webhookUrl: "",
+      events: [...NOTIFICATION_EVENTS],
+    },
+    telegram: {
+      enabled: false,
+      botToken: "",
+      chatId: "",
+      events: [...NOTIFICATION_EVENTS],
+    },
     email: {
       enabled: false,
       smtpHost: "",
@@ -26,18 +36,74 @@ const defaultSettings: NotificationSettings = {
       smtpPass: "",
       fromAddress: "",
       toAddresses: [],
+      events: [...NOTIFICATION_EVENTS],
     },
-    slack: { enabled: false, webhookUrl: "" },
-  },
-  events: {
-    sync_complete: ["discord", "telegram", "email", "slack"],
-    sync_error: ["discord", "telegram", "email", "slack"],
-    sync_aborted: ["discord", "telegram", "email", "slack"],
-    sync_safety_halt: ["discord", "telegram", "email", "slack"],
-    scrub_complete: ["discord", "telegram", "email", "slack"],
-    scrub_error: ["discord", "telegram", "email", "slack"],
+    slack: { enabled: false, webhookUrl: "", events: [...NOTIFICATION_EVENTS] },
   },
 };
+
+type LegacyNotificationSettings = Partial<NotificationSettings> & {
+  events?: Partial<Record<NotificationEvent, NotificationChannel[]>>;
+};
+
+function normalizeNotificationSettings(
+  settings: LegacyNotificationSettings | undefined
+): NotificationSettings {
+  if (!settings) {
+    return defaultSettings;
+  }
+
+  const legacyEvents = settings.events;
+  const getLegacyEventsForChannel = (channel: NotificationChannel) =>
+    NOTIFICATION_EVENTS.filter((event) =>
+      legacyEvents?.[event]?.includes(channel)
+    );
+
+  return {
+    channels: {
+      discord: {
+        ...defaultSettings.channels.discord,
+        ...settings.channels?.discord,
+        events:
+          settings.channels?.discord?.events?.length
+            ? settings.channels.discord.events
+            : getLegacyEventsForChannel("discord").length
+            ? getLegacyEventsForChannel("discord")
+            : defaultSettings.channels.discord.events,
+      },
+      telegram: {
+        ...defaultSettings.channels.telegram,
+        ...settings.channels?.telegram,
+        events:
+          settings.channels?.telegram?.events?.length
+            ? settings.channels.telegram.events
+            : getLegacyEventsForChannel("telegram").length
+            ? getLegacyEventsForChannel("telegram")
+            : defaultSettings.channels.telegram.events,
+      },
+      email: {
+        ...defaultSettings.channels.email,
+        ...settings.channels?.email,
+        events:
+          settings.channels?.email?.events?.length
+            ? settings.channels.email.events
+            : getLegacyEventsForChannel("email").length
+            ? getLegacyEventsForChannel("email")
+            : defaultSettings.channels.email.events,
+      },
+      slack: {
+        ...defaultSettings.channels.slack,
+        ...settings.channels?.slack,
+        events:
+          settings.channels?.slack?.events?.length
+            ? settings.channels.slack.events
+            : getLegacyEventsForChannel("slack").length
+            ? getLegacyEventsForChannel("slack")
+            : defaultSettings.channels.slack.events,
+      },
+    },
+  };
+}
 
 /**
  * Load notification settings from app config
@@ -50,7 +116,7 @@ export async function loadNotificationSettings(): Promise<NotificationSettings> 
   try {
     const content = await fs.readFile(APP_CONFIG_FILE, "utf-8");
     const config = JSON.parse(content);
-    return config.notifications || defaultSettings;
+    return normalizeNotificationSettings(config.notifications);
   } catch {
     return defaultSettings;
   }
@@ -86,8 +152,6 @@ export async function sendNotification(
   results: Record<NotificationChannel, boolean>;
 }> {
   const settings = await loadNotificationSettings();
-  const channels = settings.events[event] || [];
-
   const results: Record<NotificationChannel, boolean> = {
     discord: false,
     telegram: false,
@@ -97,7 +161,10 @@ export async function sendNotification(
 
   const promises: Promise<void>[] = [];
 
-  if (channels.includes("discord") && settings.channels.discord.enabled) {
+  if (
+    settings.channels.discord.events.includes(event) &&
+    settings.channels.discord.enabled
+  ) {
     promises.push(
       sendDiscordNotification(
         settings.channels.discord,
@@ -111,7 +178,10 @@ export async function sendNotification(
     );
   }
 
-  if (channels.includes("telegram") && settings.channels.telegram.enabled) {
+  if (
+    settings.channels.telegram.events.includes(event) &&
+    settings.channels.telegram.enabled
+  ) {
     promises.push(
       sendTelegramNotification(
         settings.channels.telegram,
@@ -125,7 +195,10 @@ export async function sendNotification(
     );
   }
 
-  if (channels.includes("email") && settings.channels.email.enabled) {
+  if (
+    settings.channels.email.events.includes(event) &&
+    settings.channels.email.enabled
+  ) {
     promises.push(
       sendEmailNotification(
         settings.channels.email,
@@ -139,7 +212,10 @@ export async function sendNotification(
     );
   }
 
-  if (channels.includes("slack") && settings.channels.slack.enabled) {
+  if (
+    settings.channels.slack.events.includes(event) &&
+    settings.channels.slack.enabled
+  ) {
     promises.push(
       sendSlackNotification(
         settings.channels.slack,

--- a/backend/src/services/notifications/notifications.test.ts
+++ b/backend/src/services/notifications/notifications.test.ts
@@ -4,8 +4,10 @@ import { mkdtempSync, existsSync } from "fs";
 import path from "path";
 import { tmpdir } from "os";
 import { silenceConsole } from "../../test-utils/silence-console";
+import { NOTIFICATION_EVENTS } from "@snapraid-webui/shared";
 const { mock } = await import("bun:test");
 const tmpDir = mkdtempSync(path.join(tmpdir(), "notif-"));
+process.env.CONFIG_PATH = tmpDir;
 const configModule = await import("../../config");
 const configPath =
   configModule.APP_CONFIG_FILE || path.join(tmpDir, "app-config.json");
@@ -174,14 +176,54 @@ describe("loadNotificationSettings", () => {
     const settings = await notifications.loadNotificationSettings();
     expect(settings.channels.discord.enabled).toBe(false);
     expect(settings.channels.telegram.enabled).toBe(false);
-    expect(settings.events.sync_complete).toContain("discord");
+    expect(settings.channels.discord.events).toEqual(NOTIFICATION_EVENTS);
   });
 
   test("returns default settings when config is invalid JSON", async () => {
     await fs.writeFile(configPath, "{bad json", "utf-8");
     const settings = await notifications.loadNotificationSettings();
     expect(settings.channels.email.enabled).toBe(false);
-    expect(settings.events.scrub_error).toContain("slack");
+    expect(settings.channels.slack.events).toEqual(NOTIFICATION_EVENTS);
+  });
+
+  test("migrates legacy events map into per-channel selections", async () => {
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          notifications: {
+            channels: {
+              discord: { enabled: true, webhookUrl: "http://discord" },
+              telegram: { enabled: false, botToken: "", chatId: "" },
+              email: {
+                enabled: false,
+                smtpHost: "",
+                smtpPort: 587,
+                smtpSecure: false,
+                smtpUser: "",
+                smtpPass: "",
+                fromAddress: "",
+                toAddresses: [],
+              },
+              slack: { enabled: true, webhookUrl: "http://slack" },
+            },
+            events: {
+              sync_complete: ["discord", "slack"],
+              scrub_error: ["slack"],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      "utf-8"
+    );
+    const settings = await notifications.loadNotificationSettings();
+    expect(settings.channels.discord.events).toEqual(["sync_complete"]);
+    expect(settings.channels.slack.events).toEqual([
+      "sync_complete",
+      "scrub_error",
+    ]);
   });
 });
 
@@ -224,8 +266,17 @@ describe("sendNotification", () => {
         {
           notifications: {
             channels: {
-              discord: { enabled: false, webhookUrl: "" },
-              telegram: { enabled: false, botToken: "", chatId: "" },
+              discord: {
+                enabled: false,
+                webhookUrl: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
+              telegram: {
+                enabled: false,
+                botToken: "",
+                chatId: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
               email: {
                 enabled: false,
                 smtpHost: "",
@@ -235,11 +286,13 @@ describe("sendNotification", () => {
                 smtpPass: "",
                 fromAddress: "",
                 toAddresses: [],
+                events: [...NOTIFICATION_EVENTS],
               },
-              slack: { enabled: false, webhookUrl: "" },
-            },
-            events: {
-              sync_complete: ["discord", "telegram", "email", "slack"],
+              slack: {
+                enabled: false,
+                webhookUrl: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
             },
           },
         },
@@ -277,8 +330,17 @@ describe("sendNotification", () => {
         {
           notifications: {
             channels: {
-              discord: { enabled: true, webhookUrl: "http://discord" },
-              telegram: { enabled: false, botToken: "", chatId: "" },
+              discord: {
+                enabled: true,
+                webhookUrl: "http://discord",
+                events: ["sync_complete"],
+              },
+              telegram: {
+                enabled: false,
+                botToken: "",
+                chatId: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
               email: {
                 enabled: false,
                 smtpHost: "",
@@ -288,11 +350,13 @@ describe("sendNotification", () => {
                 smtpPass: "",
                 fromAddress: "",
                 toAddresses: [],
+                events: [...NOTIFICATION_EVENTS],
               },
-              slack: { enabled: true, webhookUrl: "http://slack" },
-            },
-            events: {
-              sync_complete: ["discord", "slack"],
+              slack: {
+                enabled: true,
+                webhookUrl: "http://slack",
+                events: ["sync_complete"],
+              },
             },
           },
         },
@@ -313,6 +377,58 @@ describe("sendNotification", () => {
     expect(fetchCalls.length).toBe(2);
     restore();
   });
+
+  test("skips enabled channels when event is not selected", async () => {
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          notifications: {
+            channels: {
+              discord: {
+                enabled: true,
+                webhookUrl: "http://discord",
+                events: ["sync_complete"],
+              },
+              telegram: {
+                enabled: false,
+                botToken: "",
+                chatId: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
+              email: {
+                enabled: false,
+                smtpHost: "",
+                smtpPort: 587,
+                smtpSecure: false,
+                smtpUser: "",
+                smtpPass: "",
+                fromAddress: "",
+                toAddresses: [],
+                events: [...NOTIFICATION_EVENTS],
+              },
+              slack: {
+                enabled: true,
+                webhookUrl: "http://slack",
+                events: ["scrub_error"],
+              },
+            },
+          },
+        },
+        null,
+        2
+      ),
+      "utf-8"
+    );
+    const result = await notifications.sendNotification(
+      "sync_complete",
+      "Title",
+      "Message"
+    );
+    expect(result.results.discord).toBe(true);
+    expect(result.results.slack).toBe(false);
+    expect(fetchCalls.length).toBe(1);
+  });
 });
 
 describe("testNotificationChannel", () => {
@@ -323,8 +439,17 @@ describe("testNotificationChannel", () => {
         {
           notifications: {
             channels: {
-              discord: { enabled: false, webhookUrl: "" },
-              telegram: { enabled: false, botToken: "", chatId: "" },
+              discord: {
+                enabled: false,
+                webhookUrl: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
+              telegram: {
+                enabled: false,
+                botToken: "",
+                chatId: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
               email: {
                 enabled: false,
                 smtpHost: "",
@@ -334,11 +459,13 @@ describe("testNotificationChannel", () => {
                 smtpPass: "",
                 fromAddress: "",
                 toAddresses: [],
+                events: [...NOTIFICATION_EVENTS],
               },
-              slack: { enabled: false, webhookUrl: "" },
-            },
-            events: {
-              sync_complete: ["discord"],
+              slack: {
+                enabled: false,
+                webhookUrl: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
             },
           },
         },
@@ -363,8 +490,17 @@ describe("testNotificationChannel", () => {
         {
           notifications: {
             channels: {
-              discord: { enabled: false, webhookUrl: "" },
-              telegram: { enabled: false, botToken: "", chatId: "" },
+              discord: {
+                enabled: false,
+                webhookUrl: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
+              telegram: {
+                enabled: false,
+                botToken: "",
+                chatId: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
               email: {
                 enabled: true,
                 smtpHost: "smtp.test",
@@ -374,11 +510,13 @@ describe("testNotificationChannel", () => {
                 smtpPass: "",
                 fromAddress: "from@test",
                 toAddresses: ["to@test"],
+                events: [...NOTIFICATION_EVENTS],
               },
-              slack: { enabled: false, webhookUrl: "" },
-            },
-            events: {
-              sync_complete: ["email"],
+              slack: {
+                enabled: false,
+                webhookUrl: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
             },
           },
         },
@@ -399,8 +537,17 @@ describe("testNotificationChannel", () => {
         {
           notifications: {
             channels: {
-              discord: { enabled: false, webhookUrl: "" },
-              telegram: { enabled: false, botToken: "", chatId: "" },
+              discord: {
+                enabled: false,
+                webhookUrl: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
+              telegram: {
+                enabled: false,
+                botToken: "",
+                chatId: "",
+                events: [...NOTIFICATION_EVENTS],
+              },
               email: {
                 enabled: false,
                 smtpHost: "",
@@ -410,11 +557,13 @@ describe("testNotificationChannel", () => {
                 smtpPass: "",
                 fromAddress: "",
                 toAddresses: [],
+                events: [...NOTIFICATION_EVENTS],
               },
-              slack: { enabled: true, webhookUrl: "http://slack" },
-            },
-            events: {
-              sync_complete: ["slack"],
+              slack: {
+                enabled: true,
+                webhookUrl: "http://slack",
+                events: [...NOTIFICATION_EVENTS],
+              },
             },
           },
         },

--- a/backend/src/services/notifications/telegram.test.ts
+++ b/backend/src/services/notifications/telegram.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, mock, beforeAll, afterAll } from "bun:test";
 import { sendTelegramNotification } from "./telegram";
 import { silenceConsole } from "../../test-utils/silence-console";
+import { NOTIFICATION_EVENTS } from "@snapraid-webui/shared";
 
 const originalFetch = globalThis.fetch;
 
@@ -29,7 +30,12 @@ afterAll(() => {
 describe("sendTelegramNotification", () => {
   test("returns false when not enabled", async () => {
     const result = await sendTelegramNotification(
-      { enabled: false, botToken: "token", chatId: "123" },
+      {
+        enabled: false,
+        botToken: "token",
+        chatId: "123",
+        events: [...NOTIFICATION_EVENTS],
+      },
       "sync_complete",
       "Title",
       "Message"
@@ -39,7 +45,7 @@ describe("sendTelegramNotification", () => {
 
   test("returns false when botToken is empty", async () => {
     const result = await sendTelegramNotification(
-      { enabled: true, botToken: "", chatId: "123" },
+      { enabled: true, botToken: "", chatId: "123", events: [...NOTIFICATION_EVENTS] },
       "sync_complete",
       "Title",
       "Message"
@@ -49,7 +55,7 @@ describe("sendTelegramNotification", () => {
 
   test("returns false when chatId is empty", async () => {
     const result = await sendTelegramNotification(
-      { enabled: true, botToken: "token", chatId: "" },
+      { enabled: true, botToken: "token", chatId: "", events: [...NOTIFICATION_EVENTS] },
       "sync_complete",
       "Title",
       "Message"
@@ -59,7 +65,12 @@ describe("sendTelegramNotification", () => {
 
   test("sends message and returns true when API succeeds", async () => {
     const result = await sendTelegramNotification(
-      { enabled: true, botToken: "test-token", chatId: "123" },
+      {
+        enabled: true,
+        botToken: "test-token",
+        chatId: "123",
+        events: [...NOTIFICATION_EVENTS],
+      },
       "sync_complete",
       "Sync completed",
       "Message body",
@@ -89,7 +100,12 @@ describe("sendTelegramNotification", () => {
     );
     const restore = silenceConsole();
     const result = await sendTelegramNotification(
-      { enabled: true, botToken: "token", chatId: "123" },
+      {
+        enabled: true,
+        botToken: "token",
+        chatId: "123",
+        events: [...NOTIFICATION_EVENTS],
+      },
       "sync_error",
       "Title",
       "Message"

--- a/frontend/src/components/NotificationProviderEditDialog.tsx
+++ b/frontend/src/components/NotificationProviderEditDialog.tsx
@@ -14,6 +14,7 @@ import { Switch } from "@/components/ui/switch";
 import { Send } from "lucide-react";
 import type {
   NotificationChannel,
+  NotificationEvent,
   NotificationSettings,
   DiscordSettings,
   TelegramSettings,
@@ -21,6 +22,7 @@ import type {
   SlackSettings,
 } from "@shared/types";
 import type { ChannelConfig } from "@/lib/notification-channel-utils";
+import { NOTIFICATION_EVENTS } from "@shared/types";
 
 interface NotificationProviderEditDialogProps {
   channel: NotificationChannel;
@@ -64,10 +66,25 @@ export function NotificationProviderEditDialog({
   const [draft, setDraft] = useState<ChannelConfig>(current);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
+  const eventLabels: Record<NotificationEvent, string> = {
+    sync_complete: "Sync complete",
+    sync_error: "Sync error",
+    sync_aborted: "Sync aborted",
+    sync_safety_halt: "Sync safety halt",
+    scrub_complete: "Scrub complete",
+    scrub_error: "Scrub error",
+  };
 
   useEffect(() => {
     if (open) {
-      setDraft(getChannelConfig(settings, channel));
+      const currentConfig = getChannelConfig(settings, channel);
+      setDraft({
+        ...currentConfig,
+        events:
+          currentConfig.events?.length > 0
+            ? currentConfig.events
+            : [...NOTIFICATION_EVENTS],
+      });
     }
   }, [open, settings, channel]);
 
@@ -108,6 +125,14 @@ export function NotificationProviderEditDialog({
       ? "Email"
       : "Slack";
 
+  const toggleEvent = (event: NotificationEvent) => {
+    const currentEvents = draft.events ?? [];
+    const nextEvents = currentEvents.includes(event)
+      ? currentEvents.filter((value) => value !== event)
+      : [...currentEvents, event];
+    setDraft({ ...draft, events: nextEvents });
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md" showCloseButton>
@@ -144,6 +169,28 @@ export function NotificationProviderEditDialog({
               onChange={setDraft as (c: SlackSettings) => void}
             />
           )}
+          <div className="space-y-3">
+            <div>
+              <Label>Notification events</Label>
+              <p className="text-sm text-muted-foreground">
+                Select which events trigger notifications for this channel.
+              </p>
+            </div>
+            <div className="space-y-2">
+              {NOTIFICATION_EVENTS.map((event) => (
+                <div key={event} className="flex items-center gap-2">
+                  <Switch
+                    id={`event-${channel}-${event}`}
+                    checked={draft.events?.includes(event) ?? false}
+                    onCheckedChange={() => toggleEvent(event)}
+                  />
+                  <Label htmlFor={`event-${channel}-${event}`}>
+                    {eventLabels[event]}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
 
         <DialogFooter showCloseButton={false}>

--- a/frontend/src/lib/notification-channel-utils.ts
+++ b/frontend/src/lib/notification-channel-utils.ts
@@ -6,12 +6,18 @@ import type {
   EmailSettings,
   SlackSettings,
 } from "@shared/types";
+import { NOTIFICATION_EVENTS } from "@shared/types";
 
-const EMPTY_DISCORD: DiscordSettings = { enabled: false, webhookUrl: "" };
+const EMPTY_DISCORD: DiscordSettings = {
+  enabled: false,
+  webhookUrl: "",
+  events: [...NOTIFICATION_EVENTS],
+};
 const EMPTY_TELEGRAM: TelegramSettings = {
   enabled: false,
   botToken: "",
   chatId: "",
+  events: [...NOTIFICATION_EVENTS],
 };
 const EMPTY_EMAIL: EmailSettings = {
   enabled: false,
@@ -22,8 +28,13 @@ const EMPTY_EMAIL: EmailSettings = {
   smtpPass: "",
   fromAddress: "",
   toAddresses: [],
+  events: [...NOTIFICATION_EVENTS],
 };
-const EMPTY_SLACK: SlackSettings = { enabled: false, webhookUrl: "" };
+const EMPTY_SLACK: SlackSettings = {
+  enabled: false,
+  webhookUrl: "",
+  events: [...NOTIFICATION_EVENTS],
+};
 
 export type ChannelConfig =
   | DiscordSettings

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -248,19 +248,30 @@ export type NotificationEvent =
   | "scrub_complete"
   | "scrub_error";
 
-export interface DiscordSettings {
+export const NOTIFICATION_EVENTS: NotificationEvent[] = [
+  "sync_complete",
+  "sync_error",
+  "sync_aborted",
+  "sync_safety_halt",
+  "scrub_complete",
+  "scrub_error",
+];
+
+interface NotificationChannelSettingsBase {
   enabled: boolean;
+  events: NotificationEvent[];
+}
+
+export interface DiscordSettings extends NotificationChannelSettingsBase {
   webhookUrl: string;
 }
 
-export interface TelegramSettings {
-  enabled: boolean;
+export interface TelegramSettings extends NotificationChannelSettingsBase {
   botToken: string;
   chatId: string;
 }
 
-export interface EmailSettings {
-  enabled: boolean;
+export interface EmailSettings extends NotificationChannelSettingsBase {
   smtpHost: string;
   smtpPort: number;
   smtpSecure: boolean;
@@ -270,8 +281,7 @@ export interface EmailSettings {
   toAddresses: string[];
 }
 
-export interface SlackSettings {
-  enabled: boolean;
+export interface SlackSettings extends NotificationChannelSettingsBase {
   webhookUrl: string;
 }
 
@@ -282,7 +292,6 @@ export interface NotificationSettings {
     email: EmailSettings;
     slack: SlackSettings;
   };
-  events: Record<NotificationEvent, NotificationChannel[]>;
 }
 
 // ============================================================================


### PR DESCRIPTION
### Motivation

- Allow users to choose which events trigger notifications for each channel instead of a global event-to-channels map. 
- Persist per-channel event selections in the app config and support existing configs by migrating the legacy events map. 

### Description

- Introduce `NOTIFICATION_EVENTS` and a `events: NotificationEvent[]` field on each channel settings type in `shared/types.ts`, plus a small `NotificationChannelSettingsBase` type. 
- Update backend defaults and add `normalizeNotificationSettings` to load legacy `events` maps and convert them into per-channel selections, and change `sendNotification` to only dispatch to enabled channels that have the event selected. 
- Update the Settings UI: initialize drafts with channel `events`, add event toggles to `NotificationProviderEditDialog`, and update `getEmptyChannelConfig` defaults to include all events. 
- Update unit tests to cover migration and per-channel filtering, and adjust Telegram tests to include the new `events` field. 

### Testing

- Ran `bun test backend/src/services/notifications/notifications.test.ts` which passed (24 tests, 0 failures). 
- Ran backend and frontend typechecks with `bun run --filter @snapraid-webui/backend typecheck` and `bun run --filter @snapraid-webui/frontend typecheck`, both succeeded. 
- Ran frontend lint (`bun run --filter @snapraid-webui/frontend lint`) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980fad2e2b88326a74210bb3bc70a2f)