### PR TITLE
Add Slack notification fallback text and tests

### DIFF
--- a/backend/src/services/notifications/slack.test.ts
+++ b/backend/src/services/notifications/slack.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import type { SlackSettings } from "@snapraid-webui/shared";
+import { sendSlackNotification } from "./slack";
+
+const fetchCalls: Array<{ url: string; options: RequestInit }> = [];
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  globalThis.fetch = (async (url: string, options: RequestInit) => {
+    fetchCalls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ ok: true }),
+    } as Response;
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("sendSlackNotification", () => {
+  const baseSettings: SlackSettings = {
+    enabled: true,
+    webhookUrl: "https://hooks.slack.test/services/abc",
+    events: ["sync_complete"],
+  };
+
+  test("returns false when disabled or missing webhook", async () => {
+    const disabled = await sendSlackNotification(
+      { ...baseSettings, enabled: false },
+      "sync_complete",
+      "Title",
+      "Message"
+    );
+    const missingWebhook = await sendSlackNotification(
+      { ...baseSettings, webhookUrl: "" },
+      "sync_complete",
+      "Title",
+      "Message"
+    );
+
+    expect(disabled).toBe(false);
+    expect(missingWebhook).toBe(false);
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("sends Slack payload with fallback text and details fields", async () => {
+    const result = await sendSlackNotification(
+      baseSettings,
+      "sync_complete",
+      "Sync completed",
+      "All files were synced",
+      { Host: "nas-01" }
+    );
+
+    expect(result).toBe(true);
+    expect(fetchCalls.length).toBe(1);
+    const payload = JSON.parse(fetchCalls[0].options.body as string);
+    expect(payload.text).toContain("Sync completed");
+    expect(payload.text).toContain("All files were synced");
+    expect(payload.attachments[0].color).toBe("#36a64f");
+    expect(payload.attachments[0].blocks[0].type).toBe("header");
+    expect(payload.attachments[0].blocks[2].fields[0].text).toContain(
+      "*Host:*"
+    );
+  });
+
+  test("omits details block when no details provided", async () => {
+    const result = await sendSlackNotification(
+      baseSettings,
+      "sync_complete",
+      "Sync completed",
+      "All files were synced",
+      {}
+    );
+
+    expect(result).toBe(true);
+    expect(fetchCalls.length).toBe(1);
+    const payload = JSON.parse(fetchCalls[0].options.body as string);
+    expect(payload.attachments[0].blocks).toHaveLength(2);
+  });
+});

--- a/backend/src/services/notifications/slack.ts
+++ b/backend/src/services/notifications/slack.ts
@@ -14,6 +14,7 @@ interface SlackBlock {
 }
 
 interface SlackMessage {
+  text?: string;
   blocks?: SlackBlock[];
   attachments?: Array<{
     color: string;
@@ -75,7 +76,7 @@ export async function sendSlackNotification(
     },
   ];
 
-  if (details) {
+  if (details && Object.keys(details).length > 0) {
     const fields = Object.entries(details).map(([key, value]) => ({
       type: "mrkdwn" as const,
       text: `*${key}:*\n${value}`,
@@ -88,6 +89,7 @@ export async function sendSlackNotification(
   }
 
   const payload: SlackMessage = {
+    text: `${title}\n${message}`,
     attachments: [
       {
         color: colors[event] || "#0099ff",


### PR DESCRIPTION
### Motivation
- Ensure Slack webhooks include a plain-text fallback so messages are visible in integrations that ignore block attachments.
- Avoid sending an empty details section when no details are provided to prevent empty/ugly blocks in Slack messages.

### Description
- Added an optional `text` field to the Slack webhook payload and populate it with the `title` and `message` as a fallback.
- Guard details block creation so the details section is only added when `details` contains at least one key.
- Added unit tests `backend/src/services/notifications/slack.test.ts` covering disabled/missing webhook behavior, payload formatting with fallback text and details fields, and omission of the details block when empty.
- Modified `backend/src/services/notifications/slack.ts` to implement the above behavior.

### Testing
- Ran `bun test backend/src/services/notifications/slack.test.ts` which passed all 3 tests (3 pass, 0 fail). 
- Verified backend and frontend typechecks with `bun run --filter @snapraid-webui/backend typecheck` and `bun run --filter @snapraid-webui/frontend typecheck`, both succeeded. 
- Ran frontend lint with `bun run --filter @snapraid-webui/frontend lint` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698103c98c508326a74056a0a2d9c760)