### PR TITLE
Fix flaky CI test failure caused by unhandled WebSocket errors

### DIFF
--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -38,6 +38,16 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     const ws = new WebSocket(wsUrl)
     wsRef.current = ws
 
+    // Bun's WebSocket test/runtime implementation can surface transport errors through
+    // EventEmitter-style `error` events. Attach a listener early to prevent an
+    // unhandled error from escaping between tests when a socket fails to connect.
+    const wsWithNodeEvents = ws as WebSocket & {
+      on?: (event: string, listener: (...args: unknown[]) => void) => void
+    }
+    wsWithNodeEvents.on?.("error", () => {
+      // `ws.onerror` handles logging; this keeps Node-style emitters from being unhandled.
+    })
+
     ws.onopen = () => {
       console.log("WebSocket connected")
       setIsConnected(true)


### PR DESCRIPTION
### Motivation
- Prevent intermittent CI test failures caused by unhandled Node/EventEmitter-style `error` events emitted by the WebSocket implementation (observed in Bun) during test teardown or failed connection attempts.

### Description
- Add a defensive Node-style `error` listener immediately after creating the socket in `frontend/src/hooks/use-websocket.ts` so transport `error` events are consumed while leaving browser-style `ws.onerror` logging and reconnect behavior unchanged.

### Testing
- Ran `bun test frontend/src/hooks/use-websocket.test.ts backend/src/middleware/auth.test.ts` and the tests passed, and the pre-commit checks (`typecheck` and `lint`) also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb38d72c48326af79f69049119254)