### PR TITLE
Avoid starting backend in tests and harden WebSocket sends to fix CI flake

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,20 @@ import { initializeScheduler } from "./services/scheduler"
 import { createSessionMiddleware, authMiddleware } from "./middleware/auth"
 import { errorMiddleware } from "./middleware/async-handler"
 
+/**
+ * Bun test discovery/execution can evaluate non-test source files in some CI setups.
+ * Guard server startup side-effects in that mode to keep unit tests isolated.
+ */
+export function isTestRuntime(
+  argv: string[] = process.argv,
+  nodeEnv: string | undefined = process.env.NODE_ENV,
+): boolean {
+  return (
+    nodeEnv === "test" ||
+    argv.some((arg) => arg === "test" || arg.includes("bun:test"))
+  )
+}
+
 const app: Express = express()
 const server = createServer(app)
 
@@ -90,14 +104,15 @@ if (existsSync(frontendPath)) {
   })
 }
 
-// Initialize WebSocket
-initializeWebSocket(server)
+async function startServer(): Promise<void> {
+  // Initialize WebSocket
+  initializeWebSocket(server)
 
-// Initialize scheduler
-initializeScheduler().catch(console.error)
+  // Initialize scheduler
+  initializeScheduler().catch(console.error)
 
-server.listen(PORT, () => {
-  console.log(`
+  server.listen(PORT, () => {
+    console.log(`
 ╔═══════════════════════════════════════════════════════╗
 ║           SnapRAID Web UI Server                      ║
 ╠═══════════════════════════════════════════════════════╣
@@ -106,6 +121,14 @@ server.listen(PORT, () => {
 ║  Config path: ${CONFIG_PATH.slice(0, 38).padEnd(38)}║
 ╚═══════════════════════════════════════════════════════╝
   `)
-})
+  })
+}
 
-export { app, server }
+if (import.meta.main && !isTestRuntime()) {
+  startServer().catch((error) => {
+    console.error("Failed to start server:", error)
+    process.exit(1)
+  })
+}
+
+export { app, server, startServer }

--- a/backend/src/websocket.ts
+++ b/backend/src/websocket.ts
@@ -23,9 +23,30 @@ function broadcast(message: WSMessage): void {
   const data = JSON.stringify(message)
   for (const client of clients) {
     if (client.readyState === WebSocket.OPEN) {
-      client.send(data)
+      client.send(data, (error) => {
+        if (error) {
+          console.error("WebSocket broadcast send error:", error)
+          clients.delete(client)
+        }
+      })
     }
   }
+}
+
+/**
+ * Send a message to a specific client and guard against send-time errors
+ */
+function sendToClient(ws: WebSocket, message: WSMessage): void {
+  if (ws.readyState !== WebSocket.OPEN) {
+    return
+  }
+
+  ws.send(JSON.stringify(message), (error) => {
+    if (error) {
+      console.error("WebSocket client send error:", error)
+      clients.delete(ws)
+    }
+  })
 }
 
 /**
@@ -134,24 +155,30 @@ export function initializeWebSocket(server: Server): WebSocketServer {
     console.log("WebSocket client connected")
     clients.add(ws)
 
+    ws.on("close", () => {
+      console.log("WebSocket client disconnected")
+      clients.delete(ws)
+    })
+
+    ws.on("error", (error) => {
+      console.error("WebSocket error:", error)
+      clients.delete(ws)
+    })
+
     // Send connected message
-    ws.send(
-      JSON.stringify({
-        type: "connected",
-        timestamp: new Date().toISOString(),
-      } satisfies WSMessage),
-    )
+    sendToClient(ws, {
+      type: "connected",
+      timestamp: new Date().toISOString(),
+    })
 
     // Send current job status if any
     const currentJob = snapraidRunner.getCurrentJob()
     if (currentJob) {
-      ws.send(
-        JSON.stringify({
-          type: "status",
-          command: currentJob.command,
-          timestamp: currentJob.startTime,
-        } satisfies WSMessage),
-      )
+      sendToClient(ws, {
+        type: "status",
+        command: currentJob.command,
+        timestamp: currentJob.startTime,
+      })
     }
 
     ws.on("message", async (data) => {
@@ -163,13 +190,11 @@ export function initializeWebSocket(server: Server): WebSocketServer {
           const { command, args = [], syncSafetySettings } = message
 
           if (snapraidRunner.isRunning()) {
-            ws.send(
-              JSON.stringify({
-                type: "error",
-                error: "Another command is already running",
-                timestamp: new Date().toISOString(),
-              } satisfies WSMessage),
-            )
+            sendToClient(ws, {
+              type: "error",
+              error: "Another command is already running",
+              timestamp: new Date().toISOString(),
+            })
             return
           }
 
@@ -235,27 +260,15 @@ export function initializeWebSocket(server: Server): WebSocketServer {
         // Handle abort request
         if (message.type === "abort") {
           const aborted = snapraidRunner.abort()
-          ws.send(
-            JSON.stringify({
-              type: aborted ? "status" : "error",
-              error: aborted ? undefined : "No command is running",
-              timestamp: new Date().toISOString(),
-            } satisfies WSMessage),
-          )
+          sendToClient(ws, {
+            type: aborted ? "status" : "error",
+            error: aborted ? undefined : "No command is running",
+            timestamp: new Date().toISOString(),
+          })
         }
       } catch (error) {
         console.error("Error handling WebSocket message:", error)
       }
-    })
-
-    ws.on("close", () => {
-      console.log("WebSocket client disconnected")
-      clients.delete(ws)
-    })
-
-    ws.on("error", (error) => {
-      console.error("WebSocket error:", error)
-      clients.delete(ws)
     })
   })
 


### PR DESCRIPTION
### Motivation
- Intermittent CI crashes came from unhandled `ws` errors during tests caused by the backend auto-starting a live HTTP/WebSocket server in test discovery/execution contexts. 
- The previous send-hardening alone didn’t fully prevent unhandled send-time errors when sockets were initialized during tests, so startup side-effects must be avoided in test runtime.

### Description
- Add a runtime guard `isTestRuntime()` in `backend/src/index.ts` that detects test runtime via `NODE_ENV === "test"` or Bun test argv signatures, and export `startServer()` so startup side-effects can be invoked explicitly.  
- Gate server startup with `if (import.meta.main && !isTestRuntime())` so tests do not initialize the WebSocket server, scheduler, or call `server.listen(...)`.  
- Harden WebSocket sending in `backend/src/websocket.ts` by adding `sendToClient(ws, message)` that uses `ws.send(..., callback)` and prunes clients on send errors.  
- Make `broadcast()` use send callbacks and register per-connection `error` and `close` handlers immediately on `connection` to ensure socket errors are always handled.

### Testing
- Ran unit tests: `bun test backend/src/middleware/auth.test.ts` and `bun test backend/src` and the full backend suites; all reported success (no failing tests).  
- Verified `bun test ./backend/src/index.ts` does not start the server in test runtime and produces no side-effects.  
- Ran static checks: `bun run --filter @snapraid-webui/backend typecheck` and `bun run --filter @snapraid-webui/backend lint`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb38d72c48326af79f69049119254)